### PR TITLE
Forward params to twig template

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,17 @@ This will be converted into your Instagram feed as follows:
     ...
 </ul>
 ```
+
+You can also pass in twig variables, such as a custom class.
+
+```
+{{ instagram_feed({custom_class: 'someclass'}) }}
+```
+
+This will be accessible in the `partials/instagram.html.twig` as a property of a `params` variable. For example:
+
+```
+{% for post in feed|slice(0, count)  %}
+    <li class="{{ params.custom_class }}"><a href="{{ post.link }}" target="_blank"><img src="{{ post.image }}" alt=""></a></li>
+{% endfor %}
+```

--- a/instagram.php
+++ b/instagram.php
@@ -100,7 +100,8 @@ class InstagramPlugin extends Plugin
             'user_id'   => $config->get('feed_parameters.user_id'),
             'client_id' => $config->get('feed_parameters.client_id'),
             'feed'      => $this->feeds,
-            'count'     => $config->get('feed_parameters.count')
+            'count'     => $config->get('feed_parameters.count'),
+            'params'    => $params
         ];
 
         $output = $this->grav['twig']->twig()->render($this->template_html, $this->template_vars);


### PR DESCRIPTION
I'd like to forward the `$params` array which is passed to the `instagram_feed()` twig function into the twig template. This way you can pass additional params to the template and use them within the loop.

I've included a trivial example using a custom class in the readme. Obviously you have control over the classes by overriding the template so you wouldn't necessarily do it for a CSS class, but I think it demonstrates the point of passing page template defined values to the instagram partial and rendering within the loop.
